### PR TITLE
Fixed the import map in index.ejs

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -11,7 +11,7 @@
   <script type="systemjs-importmap">
     {
       "imports": {
-        "@react-mf/root-config": "http://localhost:9000/root-config.js"
+        "@react-mf/root-config": "http://localhost:9000/react-mf-root-config.js"
       }
     }
   </script>


### PR DESCRIPTION
So today I pulled down the entire React example for single-spa, intending to begin learning how this system works. I was surprised to discover that, even when following your instructions perfectly, it failed to load. The error was a 404 on loading the root-config.js. It took me a few minutes to understand why.

Your webpack setup is using the HTML Webpack Plugin, but is not using said plugin to automatically inject the bundled JavaScript. Instead, you are using a SystemJS import map to override the root config path to one running from localhost.

However, there is no file available to the webpack dev server called root-config.js. This is because the webpack dev server does not directly serve up the content of the src directory, but instead serves up the babel-transpiled code webpack generates. That code is accessed under the output file name, which in this case is react-mf-root-config.js.

Once I changed the name of the file it was looking for, the error went away.

Feel free to comment if you have any questions. Or if I did something else wrong that makes your original example work. Thank you.