### PR TITLE
Update README to use pnpm instead of yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Tutorial video: [youtube](https://www.youtube.com/watch?v=vjjcuIxqIzY&list=PLLUD
 ```sh
 git clone https://github.com/react-microfrontends/root-config.git
 cd root-config
-yarn install
-yarn start
+pnpm install
+pnpm start
 open http://localhost:9000
 ```
 


### PR DESCRIPTION
This PR updates the README instructions to reflect the project's configured package manager, `pnpm`, instead of `yarn`. The `package.json` includes a "packageManager" field set to "pnpm@9.11.0", which causes a warning when using `yarn install`.

Changes:
- Replace `yarn install` with `pnpm install`
- Replace `yarn start` with `pnpm start`

This should help prevent confusion for contributors and ensure consistent local development environments.
